### PR TITLE
Add sloc to homepage

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -100,7 +100,7 @@ title: Ronin - Toolkit for building shining CLI programs with Node.js
 		  <div class="col-md-5 col-md-offset-1">
 		    <h4>Small codebase and test coverage</h4>
 		    <p>
-		      Ronin's codebase is only X sloc.
+		      Ronin's codebase is only 269 sloc.
 		      Every piece of Ronin is carefully tested.
 		  </div>
 		  


### PR DESCRIPTION
Found this number in the readme and I thought noticed it wasn't on the homepage.
